### PR TITLE
Add a default stride parameter to draw_indexed_indirect/_count

### DIFF
--- a/include/vuk/CommandBuffer.hpp
+++ b/include/vuk/CommandBuffer.hpp
@@ -271,10 +271,10 @@ namespace vuk {
 		CommandBuffer& draw(size_t vertex_count, size_t instance_count, size_t first_vertex, size_t first_instance);
 		CommandBuffer& draw_indexed(size_t index_count, size_t instance_count, size_t first_index, int32_t vertex_offset, size_t first_instance);
 
-		CommandBuffer& draw_indexed_indirect(size_t command_count, Buffer indirect_buffer);
+		CommandBuffer& draw_indexed_indirect(size_t command_count, Buffer indirect_buffer, size_t stride = sizeof(vuk::DrawIndexedIndirectCommand));
 		CommandBuffer& draw_indexed_indirect(std::span<vuk::DrawIndexedIndirectCommand>);
 
-		CommandBuffer& draw_indexed_indirect_count(size_t max_draw_count, Buffer indirect_buffer, Buffer count_buffer);
+		CommandBuffer& draw_indexed_indirect_count(size_t max_draw_count, Buffer indirect_buffer, Buffer count_buffer, size_t stride = sizeof(vuk::DrawIndexedIndirectCommand));
 
 		CommandBuffer& dispatch(size_t group_count_x, size_t group_count_y = 1, size_t group_count_z = 1);
 		// Perform a dispatch while specifying the minimum invocation count

--- a/src/CommandBuffer.cpp
+++ b/src/CommandBuffer.cpp
@@ -292,10 +292,9 @@ namespace vuk {
 		return *this;
 	}
 
-	CommandBuffer& CommandBuffer::draw_indexed_indirect(size_t command_count, Buffer indirect_buffer) {
+	CommandBuffer& CommandBuffer::draw_indexed_indirect(size_t command_count, Buffer indirect_buffer, size_t stride) {
 		_bind_graphics_pipeline_state();
-		vkCmdDrawIndexedIndirect(command_buffer, indirect_buffer.buffer, (uint32_t)indirect_buffer.offset, (uint32_t)command_count,
-			sizeof(vuk::DrawIndexedIndirectCommand));
+		vkCmdDrawIndexedIndirect(command_buffer, indirect_buffer.buffer, (uint32_t)indirect_buffer.offset, (uint32_t)command_count, stride);
 		return *this;
 	}
 
@@ -307,10 +306,10 @@ namespace vuk {
 		return *this;
 	}
 
-	CommandBuffer& CommandBuffer::draw_indexed_indirect_count(size_t max_draw_count, Buffer indirect_buffer, Buffer count_buffer) {
+	CommandBuffer& CommandBuffer::draw_indexed_indirect_count(size_t max_draw_count, Buffer indirect_buffer, Buffer count_buffer, size_t stride) {
 		_bind_graphics_pipeline_state();
 		vkCmdDrawIndexedIndirectCount(command_buffer, indirect_buffer.buffer, indirect_buffer.offset, count_buffer.buffer, count_buffer.offset,
-			(uint32_t)max_draw_count, sizeof(vuk::DrawIndexedIndirectCommand));
+			(uint32_t)max_draw_count, stride);
 		return *this;
 	}
 


### PR DESCRIPTION
Non-default stride can be used to append custom data to each indirect draw command, after the mandatory fields. These can be then accessed by using the indirect buffer as a storage buffer.