### PR TITLE
Dimensionality detection

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -539,6 +539,9 @@ vuk::Unique<vuk::Buffer> vuk::Context::allocate_buffer(MemoryUsage mem_usage, vu
 }
 
 vuk::Texture vuk::Context::allocate_texture(vuk::ImageCreateInfo ici) {
+	ici.imageType = ici.extent.depth > 1?  vuk::ImageType::e3D :
+	                ici.extent.height > 1? vuk::ImageType::e2D :
+	                vuk::ImageType::e1D;
 	auto dst = impl->allocator.create_image(ici);
 	vuk::ImageViewCreateInfo ivci;
 	ivci.format = ici.format;
@@ -548,7 +551,9 @@ vuk::Texture vuk::Context::allocate_texture(vuk::ImageCreateInfo ici) {
 	ivci.subresourceRange.baseMipLevel = 0;
 	ivci.subresourceRange.layerCount = 1;
 	ivci.subresourceRange.levelCount = VK_REMAINING_MIP_LEVELS;
-	ivci.viewType = vuk::ImageViewType::e2D;
+	ivci.viewType = ici.imageType == vuk::ImageType::e3D? vuk::ImageViewType::e3D :
+	                ici.imageType == vuk::ImageType::e2D? vuk::ImageViewType::e2D :
+	                vuk::ImageViewType::e1D;
 	VkImageView iv;
 	vkCreateImageView(device, (VkImageViewCreateInfo*)&ivci, nullptr, &iv);
 	vuk::Texture tex{ Unique<Image>(*this, dst), Unique<ImageView>(*this, wrap(iv)) };

--- a/src/PerThreadContext.cpp
+++ b/src/PerThreadContext.cpp
@@ -125,7 +125,6 @@ std::pair<vuk::Texture, vuk::TransferStub> vuk::PerThreadContext::create_texture
 	ici.format = format;
 	ici.extent = extent;
 	ici.samples = vuk::Samples::e1;
-	ici.imageType = vuk::ImageType::e2D;
 	ici.initialLayout = vuk::ImageLayout::eUndefined;
 	ici.tiling = vuk::ImageTiling::eOptimal;
 	ici.usage = vuk::ImageUsageFlagBits::eTransferSrc | vuk::ImageUsageFlagBits::eTransferDst | vuk::ImageUsageFlagBits::eSampled;


### PR DESCRIPTION
A simple change to automatically fill in the imageType/viewType field of images and image views when using the convenience functions. As far as I can tell, this field is fully redundant so this shouldn't break existing code. Tested with 3D textures.