### PR TITLE
Fix manual allocation of multisampled textures

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -599,6 +599,7 @@ vuk::Texture vuk::Context::allocate_texture(vuk::ImageCreateInfo ici) {
 	vuk::Texture tex{ Unique<Image>(*this, dst), create_image_view(ivci) };
 	tex.extent = ici.extent;
 	tex.format = ici.format;
+	tex.sample_count = ici.samples;
 	return tex;
 }
 


### PR DESCRIPTION
Tiny fix - one bit of data wasn't inserted into `vuk::Texture` in `vuk::Context::allocate_texture()`. Without the correct `samples` value, the generated pipelines don't do multisampling.