### PR TITLE
Handle vkAcquireNextImageKHR result correctly

### DIFF
--- a/include/vuk/Image.hpp
+++ b/include/vuk/Image.hpp
@@ -330,7 +330,7 @@ namespace vuk {
 		}
 
 		explicit operator bool() const noexcept {
-			return payload.payload == VK_NULL_HANDLE;
+			return payload.payload != VK_NULL_HANDLE;
 		}
 
 		ImageView const* operator->() const noexcept {

--- a/include/vuk/Partials.hpp
+++ b/include/vuk/Partials.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "vuk/AllocatorHelpers.hpp"
 #include "vuk/RenderGraph.hpp"
 #include "vuk/Future.hpp"
 #include <math.h>
@@ -12,7 +13,7 @@ namespace vuk {
 	/// @param buffer Buffer to fill
 	/// @param src_data pointer to source data
 	/// @param size size of source data
-	inline Future<Buffer> host_data_to_buffer(Allocator& allocator, DomainFlagBits copy_domain, Buffer dst, void* src_data, size_t size) {
+	inline Future<Buffer> host_data_to_buffer(Allocator& allocator, DomainFlagBits copy_domain, Buffer dst, const void* src_data, size_t size) {
 		// host-mapped buffers just get memcpys
 		if (dst.mapped_ptr) {
 			memcpy(dst.mapped_ptr, src_data, size);


### PR DESCRIPTION
This change fixes swapchain errors when the swapchain resize is handled asynchronously, without stopping the world with `vkDeviceWaitIdle()`. With this change, no special treatment is needed on user side, who can respond to acquire/present errors by replacing the swapchain and processing next frames as normal. In particular, it's not required to skip `get_next_frame()` on a `DeviceSuperFrameResource` after attaching a new swapchain.