### PR TITLE
Extend `Unique`'s `operator bool` to builtin types

### DIFF
--- a/include/vuk/Types.hpp
+++ b/include/vuk/Types.hpp
@@ -49,7 +49,7 @@ namespace vuk {
 		}
 
 		explicit operator bool() const noexcept {
-			return payload.operator bool();
+			return static_cast<bool>(payload);
 		}
 
 		Type const* operator->() const noexcept {


### PR DESCRIPTION
`operator bool` is not defined for pointer types resulting in a compilation error. using a cast instead fixes the problem for all builtin types.