### PR TITLE
add slang support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,17 +120,19 @@ if (VUK_USE_VCC)
 endif()
 
 if (VUK_USE_SLANG)
-	set(SLANG_ENABLE_SLANG_GLSLANG ON CACHE BOOL "" )
+	set(SLANG_ENABLE_SLANG_GLSLANG OFF CACHE BOOL "" )
 	set(SLANG_ENABLE_GFX OFF CACHE BOOL "")
 	set(SLANG_ENABLE_SLANGC OFF CACHE BOOL "")
 	set(SLANG_ENABLE_TESTS OFF CACHE BOOL "")
 	set(SLANG_ENABLE_EXAMPLES OFF CACHE BOOL "")
+	set(SLANG_ENABLE_SLANGRT OFF CACHE BOOL "")
+	set(SLANG_ENABLE_SLANGD OFF CACHE BOOL "")
 	FetchContent_Declare(
 	  slang
 	  GIT_REPOSITORY https://github.com/Hatrickek/slang
 	  GIT_TAG master	
 	  GIT_SHALLOW ON
-	  GIT_SUBMODULES external/miniz external/lz4 external/spirv-headers external/spirv-tools external/glslang external/unordered_dense
+	  GIT_SUBMODULES external/miniz external/lz4 external/unordered_dense external/spirv-headers
 	)
 	FetchContent_MakeAvailable(slang)
 	target_link_libraries(vuk PRIVATE slang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ option(VUK_USE_VULKAN_SDK "Use the Vulkan SDK to locate headers and libraries" O
 option(VUK_USE_SHADERC "Link in shaderc for runtime compilation of GLSL shaders" ON)
 option(VUK_USE_DXC "Link in DirectXShaderCompiler for runtime compilation of HLSL shaders" OFF)
 option(VUK_USE_VCC "Use Vcc for runtime compilation of C shaders (experimental)" OFF)
+option(VUK_USE_SLANG "Use Slang for runtime compilation of Slang shaders" OFF)
 option(VUK_BUILD_TESTS "Build tests" OFF)
 option(VUK_FAIL_FAST "Trigger an assert upon encountering an error instead of propagating" OFF)
 option(VUK_DEBUG_ALLOCATIONS "Dump VMA allocations and give them debug names" OFF)
@@ -118,10 +119,29 @@ if (VUK_USE_VCC)
 	target_compile_definitions(vuk PRIVATE "-DVUK_VCC_INCLUDE_DIR=\"${BINARY_DIR}/share/vcc/include/\"")
 endif()
 
+if (VUK_USE_SLANG)
+	set(SLANG_ENABLE_SLANG_GLSLANG ON CACHE BOOL "" )
+	set(SLANG_ENABLE_GFX OFF CACHE BOOL "")
+	set(SLANG_ENABLE_SLANGC OFF CACHE BOOL "")
+	set(SLANG_ENABLE_TESTS OFF CACHE BOOL "")
+	set(SLANG_ENABLE_EXAMPLES OFF CACHE BOOL "")
+	FetchContent_Declare(
+	  slang
+	  GIT_REPOSITORY https://github.com/Hatrickek/slang
+	  GIT_TAG master	
+	  GIT_SHALLOW ON
+	  GIT_SUBMODULES external/miniz external/lz4 external/spirv-headers external/spirv-tools external/glslang external/unordered_dense
+	)
+	FetchContent_MakeAvailable(slang)
+	target_link_libraries(vuk PRIVATE slang)
+	target_sources(vuk PRIVATE src/shader_compilers/slang.cpp)
+endif()
+
 target_compile_definitions(vuk PUBLIC 
 								VUK_USE_SHADERC=$<BOOL:${VUK_USE_SHADERC}>
 								VUK_USE_DXC=$<BOOL:${VUK_USE_DXC}>
 								VUK_USE_VCC=$<BOOL:${VUK_USE_VCC}>
+								VUK_USE_SLANG=$<BOOL:${VUK_USE_SLANG}>
 								VUK_BUILD_TESTS=$<BOOL:${VUK_BUILD_TESTS}>
 								VUK_FAIL_FAST=$<BOOL:${VUK_FAIL_FAST}>
 								VUK_DEBUG_ALLOCATIONS=$<BOOL:${VUK_DEBUG_ALLOCATIONS}>

--- a/examples/01_triangle_slang.cpp
+++ b/examples/01_triangle_slang.cpp
@@ -1,0 +1,66 @@
+#include "example_runner.hpp"
+
+/* 01_triangle
+ * In this example we will draw a bufferless triangle, the "Hello world" of graphics programming
+ * For this, we will need to define our pipeline, and then submit a draw.
+ *
+ * These examples are powered by the example framework, which hides some of the code required, as that would be repeated for each example.
+ * Furthermore it allows launching individual examples and all examples with the example same code.
+ * Check out the framework (example_runner_*) files if interested!
+ */
+
+namespace {
+	vuk::Example x{
+		// The display name of this example
+		.name = "01_triangle_dxc",
+		// Setup code, ran once in the beginning
+		.setup =
+		    [](vuk::ExampleRunner& runner, vuk::Allocator& allocator) {
+		      // Pipelines are created by filling out a vuk::PipelineCreateInfo
+		      // In this case, we only need the shaders, we don't care about the rest of the state
+		      vuk::PipelineBaseCreateInfo pci;
+		      pci.add_slang(
+		          util::read_entire_file((root / "examples/triangle.slang").generic_string()), (root / "examples/triangle.slang").generic_string(), "VSmain");
+		      pci.add_slang(
+		          util::read_entire_file((root / "examples/triangle.slang").generic_string()), (root / "examples/triangle.slang").generic_string(), "PSmain");
+		      // The pipeline is stored with a user give name for simplicity
+		      runner.context->create_named_pipeline("triangle", pci);
+		    },
+		// Code ran every frame
+		.render =
+		    [](vuk::ExampleRunner& runner, vuk::Allocator& frame_allocator, vuk::Future target) {
+		      // We start building a rendergraph
+		      vuk::RenderGraph rg("01");
+		      // The framework provides us with an image to render to in "target"
+		      // We attach this to the rendergraph named as "01_triangle"
+		      rg.attach_in("01_triangle", std::move(target));
+		      // The rendergraph is composed of passes (vuk::Pass)
+		      // Each pass declares which resources are used
+		      // And it provides a callback which is executed when this pass is being ran
+		      rg.add_pass({ // For this example, only a color image is needed to write to (our framebuffer)
+		                    // The name is declared, and the way it will be used in the pass (color attachment - write)
+		                    .resources = { "01_triangle"_image >> vuk::eColorWrite >> "01_triangle_final" },
+		                    .execute = [](vuk::CommandBuffer& command_buffer) {
+			                    // Here commands are recorded into the command buffer for rendering
+			                    // The commands frequently mimick the Vulkan counterpart, with additional sugar
+			                    // The additional sugar is enabled by having a complete view of the rendering
+
+			                    // Set the viewport to cover the entire framebuffer
+			                    command_buffer.set_viewport(0, vuk::Rect2D::framebuffer());
+			                    // Set the scissor area to cover the entire framebuffer
+			                    command_buffer.set_scissor(0, vuk::Rect2D::framebuffer());
+			                    command_buffer
+			                        .set_rasterization({})              // Set the default rasterization state
+			                        .set_color_blend("01_triangle", {}) // Set the default color blend state
+			                        .bind_graphics_pipeline("triangle") // Recall pipeline for "triangle" and bind
+			                        .draw(3, 1, 0, 0);                  // Draw 3 vertices
+		                    } });
+
+		      // The rendergraph is given to a Future, which takes ownership and binds to the result ("01_triangle_final")
+		      // The example framework takes care of the busywork (submission, presenting)
+		      return vuk::Future{ std::make_unique<vuk::RenderGraph>(std::move(rg)), "01_triangle_final" };
+		    }
+	};
+
+	REGISTER_EXAMPLE(x);
+} // namespace

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -70,10 +70,11 @@ function(ADD_EXAMPLE name)
     target_link_libraries(${FULL_NAME} PRIVATE ${FULL_NAME}_obj vuk_example_runner_single)
     target_link_libraries(vuk_all_examples PRIVATE ${FULL_NAME}_obj)
 
-    add_custom_command(TARGET ${FULL_NAME} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${FULL_NAME}> $<TARGET_FILE_DIR:${FULL_NAME}>
-        COMMAND_EXPAND_LISTS
-    )
+    # erroring out for some reason?
+    # add_custom_command(TARGET ${FULL_NAME} POST_BUILD
+    #     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${FULL_NAME}> $<TARGET_FILE_DIR:${FULL_NAME}>
+    #     COMMAND_EXPAND_LISTS
+    #)
 endfunction(ADD_EXAMPLE)
 
 ADD_EXAMPLE(01_triangle)
@@ -82,6 +83,9 @@ if(VUK_USE_DXC)
 endif()
 if(VUK_USE_VCC)
     ADD_EXAMPLE(01_triangle_vcc)
+endif()
+if(VUK_USE_SLANG)
+    ADD_EXAMPLE(01_triangle_slang)
 endif()
 ADD_EXAMPLE(02_cube)
 ADD_EXAMPLE(03_multipass)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -70,11 +70,10 @@ function(ADD_EXAMPLE name)
     target_link_libraries(${FULL_NAME} PRIVATE ${FULL_NAME}_obj vuk_example_runner_single)
     target_link_libraries(vuk_all_examples PRIVATE ${FULL_NAME}_obj)
 
-    # erroring out for some reason?
-    # add_custom_command(TARGET ${FULL_NAME} POST_BUILD
-    #     COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${FULL_NAME}> $<TARGET_FILE_DIR:${FULL_NAME}>
-    #     COMMAND_EXPAND_LISTS
-    #)
+    add_custom_command(TARGET ${FULL_NAME} POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_RUNTIME_DLLS:${FULL_NAME}> $<TARGET_FILE_DIR:${FULL_NAME}>
+        COMMAND_EXPAND_LISTS
+    )
 endfunction(ADD_EXAMPLE)
 
 ADD_EXAMPLE(01_triangle)

--- a/examples/triangle.slang
+++ b/examples/triangle.slang
@@ -1,0 +1,27 @@
+struct VSOutput {
+    float4 position : SV_Position;
+    float3 color : Color;
+};
+
+[shader("vertex")]
+VSOutput VSmain(uint vertexID: SV_VertexID) {
+  VSOutput output;
+
+  if (vertexID == 0) {
+      output.position = float4(0.0, -0.3, 0.0, 1.0);
+      output.color = float3(0, 1, 0);
+  } else if (vertexID == 1) {
+      output.position = float4(-0.3, 0.3, 0.0, 1.0);
+      output.color = float3(1, 0, 0);
+  } else {
+      output.position = float4(0.3, 0.3, 0.0, 1.0);
+      output.color = float3(0, 0, 1);
+  }
+
+  return output;
+}
+
+[shader("fragment")]
+float4 PSmain(VSOutput input) : SV_Target {
+  return float4(input.color, 1.0);
+}

--- a/include/vuk/Pipeline.hpp
+++ b/include/vuk/Pipeline.hpp
@@ -110,6 +110,13 @@ namespace vuk {
 		}
 #endif
 
+#if VUK_USE_SLANG
+		void add_slang(std::string_view source, std::string filename, std::string entry_point = "main") {
+			shaders.emplace_back(ShaderSource::slang(source, compile_options, std::move(entry_point)));
+			shader_paths.emplace_back(std::move(filename));
+		}
+#endif
+
 		void add_spirv(std::vector<uint32_t> source, std::string filename, std::string entry_point = "main") {
 			shaders.emplace_back(ShaderSource::spirv(std::move(source), std::move(entry_point)));
 			shader_paths.emplace_back(std::move(filename));

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -71,6 +71,7 @@ namespace {
 namespace vuk {
 	Result<std::vector<uint32_t>> compile_glsl(const create_info_t<ShaderModule>& cinfo, uint32_t shader_compiler_target_version);
 	Result<std::vector<uint32_t>> compile_hlsl(const create_info_t<ShaderModule>& cinfo, uint32_t shader_compiler_target_version);
+	Result<std::vector<uint32_t>> compile_slang(const create_info_t<ShaderModule>& cinfo, uint32_t shader_compiler_target_version);
 	Result<std::vector<uint32_t>> compile_c(const create_info_t<ShaderModule>& cinfo, uint32_t shader_compiler_target_version);
 }
 
@@ -355,6 +356,14 @@ namespace vuk {
 		case ShaderSourceLanguage::eC: {
 #if VUK_USE_VCC
 			spirv = *compile_c(cinfo, shader_compiler_target_version);
+			spirv_ptr = spirv.data();
+			size = spirv.size();
+#endif
+			break;
+		}
+		case ShaderSourceLanguage::eSlang: {
+#if VUK_USE_SLANG
+			spirv = *compile_slang(cinfo, shader_compiler_target_version);
 			spirv_ptr = spirv.data();
 			size = spirv.size();
 #endif

--- a/src/shader_compilers/shaderc.cpp
+++ b/src/shader_compilers/shaderc.cpp
@@ -8,7 +8,6 @@
 
 namespace vuk {
 	Result<std::vector<uint32_t>> compile_glsl(const ShaderModuleCreateInfo& cinfo, uint32_t shader_compiler_target_version) {
-		shaderc::Compiler compiler;
 		shaderc::CompileOptions options;
 
 		static const std::unordered_map<uint32_t, uint32_t> target_version = {
@@ -34,6 +33,15 @@ namespace vuk {
 			options.AddMacroDefinition(k, v);
 		}
 
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eNoWarnings)
+			options.SetSuppressWarnings();
+		else if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eWarningsAsErrors)
+			options.SetWarningsAsErrors();
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eInvertY)
+			options.SetInvertY(true);
+
+		const shaderc::Compiler compiler;
 		const auto result = compiler.CompileGlslToSpv(cinfo.source.as_c_str(), shaderc_glsl_infer_from_source, cinfo.filename.c_str(), options);
 		if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
 			std::string message = result.GetErrorMessage();

--- a/src/shader_compilers/slang.cpp
+++ b/src/shader_compilers/slang.cpp
@@ -1,0 +1,120 @@
+﻿#include "fmt/chrono.h"
+#include "source/core/slang-list.h"
+#include "vuk/Exception.hpp"
+#include "vuk/Result.hpp"
+#include "vuk/ShaderSource.hpp"
+
+#include <filesystem>
+#include <slang-com-ptr.h>
+
+#define CHECK_RESULT(x)                                                                                                                                        \
+	if (SLANG_FAILED(SlangResult(x))) {                                                                                                                          \
+		auto err = fmt::format("Slang error: {}", x);                                                                                                              \
+		return { expected_error, ShaderCompilationException(err) };                                                                                                \
+	}
+
+#define CHECK_DIAGNOSTIC(diagnosticsBlob)                                                                                                                      \
+	if ((diagnosticsBlob) != nullptr) {                                                                                                                          \
+		auto err = fmt::format("{}", (const char*)(diagnosticsBlob)->getBufferPointer());                                                                          \
+		return { expected_error, ShaderCompilationException(err) };                                                                                                \
+	}
+
+namespace vuk {
+	Result<std::vector<uint32_t>> compile_slang(const ShaderModuleCreateInfo& cinfo, uint32_t shader_compiler_target_version) {
+		Slang::ComPtr<slang::IGlobalSession> slangGlobalSession;
+		CHECK_RESULT(slang::createGlobalSession(slangGlobalSession.writeRef()))
+
+		slang::SessionDesc sessionDesc = {};
+		slang::TargetDesc targetDesc = {};
+		targetDesc.format = SLANG_SPIRV;
+		targetDesc.profile = slangGlobalSession->findProfile("glsl440");
+		targetDesc.flags = SLANG_TARGET_FLAG_GENERATE_SPIRV_DIRECTLY;
+
+		std::vector<slang::CompilerOptionEntry> entries = {};
+		entries.emplace_back(slang::CompilerOptionName::VulkanUseEntryPointName, slang::CompilerOptionValue{ .intValue0 = true });
+
+		slang::CompilerOptionEntry opt_level_entry;
+		opt_level_entry.name = slang::CompilerOptionName::Optimization;
+		switch (cinfo.compile_options.optimization_level) {
+		case ShaderCompileOptions::OptimizationLevel::O0:
+			opt_level_entry.value.intValue0 = SLANG_OPTIMIZATION_LEVEL_NONE;
+			break;
+		case ShaderCompileOptions::OptimizationLevel::O1:
+			opt_level_entry.value.intValue0 = SLANG_OPTIMIZATION_LEVEL_DEFAULT;
+			break;
+		case ShaderCompileOptions::OptimizationLevel::O2:
+			opt_level_entry.value.intValue0 = SLANG_OPTIMIZATION_LEVEL_HIGH;
+			break;
+		case ShaderCompileOptions::OptimizationLevel::O3:
+			opt_level_entry.value.intValue0 = SLANG_OPTIMIZATION_LEVEL_MAXIMAL;
+			break;
+		}
+		entries.emplace_back(opt_level_entry);
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eGlLayout)
+			entries.emplace_back(slang::CompilerOptionName::VulkanUseGLLayout, slang::CompilerOptionValue{ .intValue0 = true });
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eNoWarnings)
+			entries.emplace_back(slang::CompilerOptionName::DisableWarnings, slang::CompilerOptionValue{ .intValue0 = true });
+		else if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eWarningsAsErrors)
+			entries.emplace_back(slang::CompilerOptionName::WarningsAsErrors, slang::CompilerOptionValue{ .intValue0 = true });
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eMatrixColumnMajor)
+			entries.emplace_back(slang::CompilerOptionName::MatrixLayoutColumn, slang::CompilerOptionValue{ .intValue0 = true });
+		else if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eMatrixRowMajor)
+			entries.emplace_back(slang::CompilerOptionName::MatrixLayoutRow, slang::CompilerOptionValue{ .intValue0 = true });
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eInvertY)
+			entries.emplace_back(slang::CompilerOptionName::VulkanInvertY, slang::CompilerOptionValue{ .intValue0 = true });
+
+		if (cinfo.compile_options.compiler_flags & ShaderCompilerFlagBits::eDxPositionW)
+			entries.emplace_back(slang::CompilerOptionName::VulkanUseDxPositionW, slang::CompilerOptionValue{ .intValue0 = true });
+
+		targetDesc.compilerOptionEntries = entries.data();
+		targetDesc.compilerOptionEntryCount = (uint32_t)entries.size();
+
+		sessionDesc.targets = &targetDesc;
+		sessionDesc.targetCount = 1;
+
+		Slang::ComPtr<slang::ISession> session;
+		CHECK_RESULT(slangGlobalSession->createSession(sessionDesc, session.writeRef()))
+
+		slang::IModule* slangModule;
+		{
+			Slang::ComPtr<slang::IBlob> diagnosticBlob;
+			slangModule = session->loadModule(cinfo.filename.c_str(), diagnosticBlob.writeRef());
+			CHECK_DIAGNOSTIC(diagnosticBlob)
+			if (!slangModule)
+				return { expected_error, ShaderCompilationException("Couldn't load the module!") };
+		}
+
+		Slang::ComPtr<slang::IEntryPoint> entryPoint;
+		slangModule->findEntryPointByName(cinfo.source.entry_point.c_str(), entryPoint.writeRef());
+
+		Slang::List<slang::IComponentType*> componentTypes;
+		componentTypes.add(slangModule);
+		componentTypes.add(entryPoint);
+
+		Slang::ComPtr<slang::IComponentType> composedProgram;
+		{
+			Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+			const SlangResult result =
+			    session->createCompositeComponentType(componentTypes.getBuffer(), componentTypes.getCount(), composedProgram.writeRef(), diagnosticsBlob.writeRef());
+			CHECK_DIAGNOSTIC(diagnosticsBlob)
+			CHECK_RESULT(result)
+		}
+
+		Slang::ComPtr<slang::IBlob> spirvCode;
+		{
+			Slang::ComPtr<slang::IBlob> diagnosticsBlob;
+			const SlangResult result = composedProgram->getEntryPointCode(0, 0, spirvCode.writeRef(), diagnosticsBlob.writeRef());
+			CHECK_DIAGNOSTIC(diagnosticsBlob)
+			CHECK_RESULT(result)
+		}
+
+		const uint32_t* begin = (const uint32_t*)spirvCode->getBufferPointer();
+		const uint32_t* end = begin + spirvCode->getBufferSize() / 4;
+
+		return { expected_value, std::vector<uint32_t>{ begin, end } };
+	}
+} // namespace vuk


### PR DESCRIPTION
TODO:
- [x] Cleanup the cmake since it might be building stuff we don't actually need.
- [x] Fix the issue with copying built binaries to the working directory. And do it for slang binaries too.
- [x] Use `ShaderCompilerFlagBits` for other backends too. (Currently only used by Slang and DXC)