### PR TITLE
Remove unused includes

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 set(TRACY_ON_DEMAND OFF)
 FetchContent_Declare(tracy
     GIT_REPOSITORY https://github.com/wolfpld/tracy.git
-    GIT_TAG 2183962ef7fc8f721019c01d9170f5ea0d509555
+    GIT_TAG 5d542dc09f3d9378d005092a4ad446bd405f819a
     GIT_SHALLOW TRUE
     GIT_PROGRESS TRUE
 )

--- a/examples/standalone_triangle.cpp
+++ b/examples/standalone_triangle.cpp
@@ -1,5 +1,3 @@
-#pragma once
-
 #include "utils.hpp"
 #include "vuk/RenderGraph.hpp"
 #include "vuk/runtime/CommandBuffer.hpp"

--- a/include/vuk/Hash.hpp
+++ b/include/vuk/Hash.hpp
@@ -1,7 +1,7 @@
 #pragma once
-#include <stdint.h>
-#include <string_view>
-#include <utility>
+
+#include <cstdint>
+#include <functional>
 
 // https://gist.github.com/filsinger/1255697/21762ea83a2d3c17561c8e6a29f44249a4626f9e
 

--- a/include/vuk/ToIntegral.hpp
+++ b/include/vuk/ToIntegral.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <utility>
+#include <type_traits>
 
 template<typename E>
 inline constexpr auto to_integral(E e) -> typename std::underlying_type<E>::type {

--- a/src/Format.cpp
+++ b/src/Format.cpp
@@ -1,5 +1,4 @@
 #include "vuk/runtime/vk/Image.hpp"
-#include "vuk/Util.hpp"
 #include <cassert>
 
 namespace vuk {

--- a/src/GraphDumper.cpp
+++ b/src/GraphDumper.cpp
@@ -1,4 +1,3 @@
-#include <fstream>
 #include <sstream>
 #include <string>
 

--- a/src/GraphDumper.cpp
+++ b/src/GraphDumper.cpp
@@ -4,6 +4,7 @@
 #if VUK_OS_WINDOWS
 #include <Windows.h>
 #include <shellapi.h>
+#include <fstream>
 #endif
 
 #include "vuk/IR.hpp"

--- a/src/IRPasses.cpp
+++ b/src/IRPasses.cpp
@@ -3,12 +3,8 @@
 #include "vuk/IRProcess.hpp"
 #include "vuk/RenderGraph.hpp"
 #include "vuk/SyncLowering.hpp"
-#include "vuk/Value.hpp"
 #include "vuk/runtime/CommandBuffer.hpp"
-#include "vuk/runtime/vk/VkRuntime.hpp"
 
-#include <bit>
-#include <charconv>
 #include <fmt/printf.h>
 #include <memory_resource>
 #include <random>
@@ -665,6 +661,7 @@ namespace vuk {
 					}
 				}
 			}
+			default:;
 			}
 		}
 

--- a/src/runtime/Cache.cpp
+++ b/src/runtime/Cache.cpp
@@ -1,11 +1,10 @@
 #include "vuk/runtime/Cache.hpp"
-#include "vuk/runtime/vk/VkRuntime.hpp"
 #include "vuk/runtime/vk/PipelineInstance.hpp"
 
+#include <mutex>
 #include <plf_colony.h>
 #include <robin_hood.h>
 #include <shared_mutex>
-#include <mutex>
 
 namespace vuk {
 	template<class T>

--- a/src/runtime/vk/Allocator.cpp
+++ b/src/runtime/vk/Allocator.cpp
@@ -1,15 +1,9 @@
 #include "vuk/runtime/vk/Allocator.hpp"
 #include "vuk/Exception.hpp"
-#include "vuk/runtime/vk/DeviceFrameResource.hpp"
-#include "vuk/runtime/vk/DeviceVkResource.hpp"
 #include "vuk/runtime/vk/PipelineInstance.hpp"
 #include "vuk/runtime/vk/Query.hpp"
 #include "vuk/runtime/vk/RenderPass.hpp"
 #include "vuk/runtime/vk/VkRuntime.hpp"
-
-#include <numeric>
-#include <string>
-#include <utility>
 
 namespace vuk {
 	BufferUsageFlags DeviceResource::get_all_buffer_usage_flags(Runtime& runtime) {

--- a/src/runtime/vk/Backend.cpp
+++ b/src/runtime/vk/Backend.cpp
@@ -2,18 +2,14 @@
 #include "vuk/IRProcess.hpp"
 #include "vuk/RenderGraph.hpp"
 #include "vuk/SyncLowering.hpp"
-#include "vuk/Util.hpp"
-#include "vuk/Value.hpp"
-#include "vuk/runtime/Cache.hpp"
 #include "vuk/runtime/CommandBuffer.hpp"
 #include "vuk/runtime/Stream.hpp"
 #include "vuk/runtime/vk/AllocatorHelpers.hpp"
+#include "vuk/runtime/vk/RenderPass.hpp"
 #include "vuk/runtime/vk/VkQueueExecutor.hpp"
 #include "vuk/runtime/vk/VkRuntime.hpp"
 
 #include <fmt/format.h>
-#include <mutex>
-#include <sstream>
 #include <unordered_set>
 #include <vector>
 
@@ -1165,7 +1161,7 @@ namespace vuk {
 	}                                                                                                                                                            \
 	dst = *reinterpret_cast<decltype(dst)*>(UNIQUE_NAME(A)->value);                                                                                              \
 	if (UNIQUE_NAME(A)->owned) {                                                                                                                                 \
-		delete[] (char*)UNIQUE_NAME(A)->value;                                                                                                                            \
+		delete[] (char*)UNIQUE_NAME(A)->value;                                                                                                                     \
 	}
 			case Node::CONSTRUCT: { // when encountering a CONSTRUCT, allocate the thing if needed
 				if (sched.process(item)) {

--- a/src/runtime/vk/BufferAllocator.cpp
+++ b/src/runtime/vk/BufferAllocator.cpp
@@ -3,7 +3,6 @@
 #include "vuk/Result.hpp"
 #include "vuk/SourceLocation.hpp"
 #include "vuk/runtime/vk/Allocator.hpp"
-#include <iostream>
 
 // Aligns given value down to nearest multiply of align value. For example: VmaAlignUp(11, 8) = 8.
 // Use types like uint32_t, uint64_t as T.

--- a/src/runtime/vk/DeviceLinearResource.cpp
+++ b/src/runtime/vk/DeviceLinearResource.cpp
@@ -6,8 +6,6 @@
 #include "vuk/runtime/vk/VkQueueExecutor.hpp"
 #include "vuk/runtime/vk/VkRuntime.hpp"
 
-#include <atomic>
-#include <mutex>
 #include <numeric>
 #include <plf_colony.h>
 

--- a/src/runtime/vk/DeviceVkResource.cpp
+++ b/src/runtime/vk/DeviceVkResource.cpp
@@ -17,7 +17,6 @@
 	} while (false)
 #endif
 #include <mutex>
-#include <numeric>
 #include <sstream>
 #include <vk_mem_alloc.h>
 

--- a/src/runtime/vk/Util.cpp
+++ b/src/runtime/vk/Util.cpp
@@ -1,7 +1,6 @@
 #include "vuk/RenderGraph.hpp"
 #include "vuk/Value.hpp"
 #include "vuk/runtime/Cache.hpp"
-#include "vuk/runtime/vk/AllocatorHelpers.hpp"
 #include "vuk/runtime/vk/DeviceVkResource.hpp"
 #include "vuk/runtime/vk/VkRuntime.hpp"
 #include "vuk/runtime/vk/VkSwapchain.hpp"

--- a/src/runtime/vk/VkQueueExecutor.cpp
+++ b/src/runtime/vk/VkQueueExecutor.cpp
@@ -1,10 +1,8 @@
 #include "vuk/runtime/vk/VkQueueExecutor.hpp"
 #include "vuk/Exception.hpp"
-#include "vuk/RenderGraph.hpp"
 #include "vuk/runtime/vk/Allocator.hpp"
+#include "vuk/runtime/vk/VkRuntime.hpp"
 
-#include <array>
-#include <atomic>
 #include <mutex>
 #include <vector>
 

--- a/src/runtime/vk/VkRuntime.cpp
+++ b/src/runtime/vk/VkRuntime.cpp
@@ -3,10 +3,9 @@
 #include <mutex>
 
 #include "vuk/Exception.hpp"
-#include "vuk/RenderGraph.hpp"
+#include "vuk/ImageAttachment.hpp"
 #include "vuk/runtime/Cache.hpp"
 #include "vuk/runtime/vk/Allocator.hpp"
-#include "vuk/runtime/vk/AllocatorHelpers.hpp"
 #include "vuk/runtime/vk/DeviceVkResource.hpp"
 #include "vuk/runtime/vk/Program.hpp"
 #include "vuk/runtime/vk/Query.hpp"
@@ -14,6 +13,7 @@
 #include "vuk/runtime/vk/VkRuntime.hpp"
 #include "vuk/runtime/vk/VkSwapchain.hpp"
 
+#include <plf_colony.h>
 #include <robin_hood.h>
 
 namespace {
@@ -765,8 +765,17 @@ namespace vuk {
 		allocator.allocate_semaphores(std::span(semaphores));
 	}
 
-	Swapchain::Swapchain(Allocator alloc, size_t image_count, VkSwapchainKHR swapchain, VkSurfaceKHR surface, VkExtent2D extent, VkFormat format, std::vector<VkImage> images, std::vector<VkImageView> views) :
-	    allocator(alloc), swapchain(swapchain), surface(surface) {
+	Swapchain::Swapchain(Allocator alloc,
+	                     size_t image_count,
+	                     VkSwapchainKHR swapchain,
+	                     VkSurfaceKHR surface,
+	                     VkExtent2D extent,
+	                     VkFormat format,
+	                     std::vector<VkImage> images,
+	                     std::vector<VkImageView> views) :
+	    allocator(alloc),
+	    swapchain(swapchain),
+	    surface(surface) {
 		semaphores.resize(image_count * 2);
 		allocator.allocate_semaphores(std::span(semaphores));
 		for (auto i = 0; i < images.size(); i++) {


### PR DESCRIPTION
Removes unused includes in source files to have less warnings during building with clang (haven't tested gcc).
I didn't remove unused header file includes to not break applications using it.

also bumps tracy because cmake fetch was complaining that it cannot find old tag