### PR TITLE
Add explicit allocation names

### DIFF
--- a/include/vuk/IR.hpp
+++ b/include/vuk/IR.hpp
@@ -828,6 +828,8 @@ namespace vuk {
 				// TODO: crimes
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Winvalid-offsetof"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Winvalid-offsetof"
 				auto image_offsets = std::vector<size_t>{ offsetof(ImageAttachment, extent) + offsetof(Extent3D, width),
 					                                        offsetof(ImageAttachment, extent) + offsetof(Extent3D, height),
 					                                        offsetof(ImageAttachment, extent) + offsetof(Extent3D, depth),
@@ -837,6 +839,7 @@ namespace vuk {
 					                                        offsetof(ImageAttachment, layer_count),
 					                                        offsetof(ImageAttachment, base_level),
 					                                        offsetof(ImageAttachment, level_count) };
+#pragma GCC diagnostic pop
 #pragma clang diagnostic pop
 				auto image_type = emplace_type(std::shared_ptr<Type>(new Type{ .kind = Type::COMPOSITE_TY,
 				                                                               .size = sizeof(ImageAttachment),

--- a/include/vuk/runtime/vk/Allocator.hpp
+++ b/include/vuk/runtime/vk/Allocator.hpp
@@ -56,6 +56,7 @@ namespace vuk {
 
 		virtual Result<void, AllocateException> allocate_buffers(std::span<Buffer> dst, std::span<const BufferCreateInfo> cis, SourceLocationAtFrame loc) = 0;
 		virtual void deallocate_buffers(std::span<const Buffer> dst) = 0;
+		virtual void set_buffer_allocation_name(Buffer& dst, Name name) = 0;
 
 		virtual Result<void, AllocateException>
 		allocate_framebuffers(std::span<VkFramebuffer> dst, std::span<const FramebufferCreateInfo> cis, SourceLocationAtFrame loc) = 0;
@@ -64,6 +65,7 @@ namespace vuk {
 		// gpu only
 		virtual Result<void, AllocateException> allocate_images(std::span<Image> dst, std::span<const ImageCreateInfo> cis, SourceLocationAtFrame loc) = 0;
 		virtual void deallocate_images(std::span<const Image> dst) = 0;
+		virtual void set_image_allocation_name(Image& dst, Name name) = 0;
 
 		virtual Result<void, AllocateException>
 		allocate_image_views(std::span<ImageView> dst, std::span<const ImageViewCreateInfo> cis, SourceLocationAtFrame loc) = 0;

--- a/include/vuk/runtime/vk/Allocator.hpp
+++ b/include/vuk/runtime/vk/Allocator.hpp
@@ -230,6 +230,11 @@ namespace vuk {
 		/// @param src Span of buffers to be deallocated
 		void deallocate(std::span<const Buffer> src);
 
+		/// @brief Set name of the underlying VMA allocation
+		/// @param dst Destination buffer
+		/// @param name Name of the allocation
+		void set_allocation_name(Buffer& dst, Name name);
+
 		/// @brief Allocate framebuffers from this Allocator
 		/// @param dst Destination span to place allocated framebuffers into
 		/// @param cis Per-element construction info
@@ -267,6 +272,11 @@ namespace vuk {
 		/// @brief Deallocate images previously allocated from this Allocator
 		/// @param src Span of images to be deallocated
 		void deallocate(std::span<const Image> src);
+
+		/// @brief Set name of the underlying VMA allocation
+		/// @param dst Destination image
+		/// @param name Name of the allocation
+		void set_allocation_name(Image& dst, Name name);
 
 		/// @brief Allocate image views from this Allocator
 		/// @param dst Destination span to place allocated image views into

--- a/include/vuk/runtime/vk/DeviceNestedResource.hpp
+++ b/include/vuk/runtime/vk/DeviceNestedResource.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "vuk/runtime/vk/Allocator.hpp"
 #include "vuk/Exception.hpp"
+#include "vuk/runtime/vk/Allocator.hpp"
 #include "vuk/vuk_fwd.hpp"
 
 namespace vuk {
@@ -32,6 +32,8 @@ namespace vuk {
 
 		void deallocate_buffers(std::span<const Buffer> src) override;
 
+		void set_buffer_allocation_name(Buffer& dst, Name name) override final;
+
 		Result<void, AllocateException>
 		allocate_framebuffers(std::span<VkFramebuffer> dst, std::span<const FramebufferCreateInfo> cis, SourceLocationAtFrame loc) override;
 
@@ -40,6 +42,8 @@ namespace vuk {
 		Result<void, AllocateException> allocate_images(std::span<Image> dst, std::span<const ImageCreateInfo> cis, SourceLocationAtFrame loc) override;
 
 		void deallocate_images(std::span<const Image> src) override;
+
+		void set_image_allocation_name(Image& dst, Name name) override final;
 
 		Result<void, AllocateException>
 		allocate_image_views(std::span<ImageView> dst, std::span<const ImageViewCreateInfo> cis, SourceLocationAtFrame loc) override;
@@ -85,8 +89,9 @@ namespace vuk {
 
 		void deallocate_swapchains(std::span<const VkSwapchainKHR> src) override;
 
-		Result<void, AllocateException>
-		allocate_graphics_pipelines(std::span<GraphicsPipelineInfo> dst, std::span<const GraphicsPipelineInstanceCreateInfo> cis, SourceLocationAtFrame loc) override;
+		Result<void, AllocateException> allocate_graphics_pipelines(std::span<GraphicsPipelineInfo> dst,
+		                                                            std::span<const GraphicsPipelineInstanceCreateInfo> cis,
+		                                                            SourceLocationAtFrame loc) override;
 		void deallocate_graphics_pipelines(std::span<const GraphicsPipelineInfo> src) override;
 
 		Result<void, AllocateException>
@@ -94,8 +99,8 @@ namespace vuk {
 		void deallocate_compute_pipelines(std::span<const ComputePipelineInfo> src) override;
 
 		Result<void, AllocateException> allocate_ray_tracing_pipelines(std::span<RayTracingPipelineInfo> dst,
-		                                                                      std::span<const RayTracingPipelineInstanceCreateInfo> cis,
-		                                                                      SourceLocationAtFrame loc) override;
+		                                                               std::span<const RayTracingPipelineInstanceCreateInfo> cis,
+		                                                               SourceLocationAtFrame loc) override;
 		void deallocate_ray_tracing_pipelines(std::span<const RayTracingPipelineInfo> src) override;
 
 		Result<void, AllocateException>

--- a/include/vuk/runtime/vk/DeviceVkResource.hpp
+++ b/include/vuk/runtime/vk/DeviceVkResource.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "vuk/runtime/vk/Allocator.hpp"
 #include "vuk/Config.hpp"
+#include "vuk/runtime/vk/Allocator.hpp"
 
 namespace vuk {
 	/// @brief Device resource that performs direct allocation from the resources from the Vulkan runtime.
@@ -38,6 +38,8 @@ namespace vuk {
 
 		void deallocate_buffers(std::span<const Buffer> src) override;
 
+		void set_buffer_allocation_name(Buffer& dst, Name name) override final;
+
 		Result<void, AllocateException>
 		allocate_framebuffers(std::span<VkFramebuffer> dst, std::span<const FramebufferCreateInfo> cis, SourceLocationAtFrame loc) override;
 
@@ -46,6 +48,8 @@ namespace vuk {
 		Result<void, AllocateException> allocate_images(std::span<Image> dst, std::span<const ImageCreateInfo> cis, SourceLocationAtFrame loc) override;
 
 		void deallocate_images(std::span<const Image> src) override;
+
+		void set_image_allocation_name(Image& dst, Name name) override final;
 
 		Result<void, AllocateException>
 		allocate_image_views(std::span<ImageView> dst, std::span<const ImageViewCreateInfo> cis, SourceLocationAtFrame loc) override;
@@ -91,7 +95,7 @@ namespace vuk {
 
 		void deallocate_swapchains(std::span<const VkSwapchainKHR> src) override;
 
-				Result<void, AllocateException> allocate_graphics_pipelines(std::span<GraphicsPipelineInfo> dst,
+		Result<void, AllocateException> allocate_graphics_pipelines(std::span<GraphicsPipelineInfo> dst,
 		                                                            std::span<const GraphicsPipelineInstanceCreateInfo> cis,
 		                                                            SourceLocationAtFrame loc) override;
 		void deallocate_graphics_pipelines(std::span<const GraphicsPipelineInfo> src) override;

--- a/src/runtime/vk/Allocator.cpp
+++ b/src/runtime/vk/Allocator.cpp
@@ -84,6 +84,10 @@ namespace vuk {
 		device_resource->deallocate_buffers(src);
 	}
 
+	void Allocator::set_allocation_name(Buffer& dst, Name name) {
+		device_resource->set_buffer_allocation_name(dst, name);
+	}
+
 	Result<void, AllocateException> Allocator::allocate(std::span<VkFramebuffer> dst, std::span<const FramebufferCreateInfo> cis, SourceLocationAtFrame loc) {
 		return device_resource->allocate_framebuffers(dst, cis, loc);
 	}
@@ -107,6 +111,10 @@ namespace vuk {
 
 	void Allocator::deallocate(std::span<const Image> src) {
 		device_resource->deallocate_images(src);
+	}
+
+	void Allocator::set_allocation_name(Image& dst, Name name) {
+		device_resource->set_image_allocation_name(dst, name);
 	}
 
 	Result<void, AllocateException> Allocator::allocate(std::span<ImageView> dst, std::span<const ImageViewCreateInfo> cis, SourceLocationAtFrame loc) {

--- a/src/runtime/vk/DeviceVkResource.cpp
+++ b/src/runtime/vk/DeviceVkResource.cpp
@@ -250,6 +250,10 @@ namespace vuk {
 		}
 	}
 
+	void DeviceVkResource::set_buffer_allocation_name(Buffer& dst, Name name) {
+		vmaSetAllocationName(impl->allocator, static_cast<VmaAllocation>(dst.allocation), name.c_str());
+	}
+
 	Result<void, AllocateException> DeviceVkResource::allocate_images(std::span<Image> dst, std::span<const ImageCreateInfo> cis, SourceLocationAtFrame loc) {
 		assert(dst.size() == cis.size());
 		for (int64_t i = 0; i < (int64_t)dst.size(); i++) {
@@ -286,6 +290,10 @@ namespace vuk {
 				vmaDestroyImage(impl->allocator, v.image, static_cast<VmaAllocation>(v.allocation));
 			}
 		}
+	}
+
+	void DeviceVkResource::set_image_allocation_name(Image& dst, Name name) {
+		vmaSetAllocationName(impl->allocator, static_cast<VmaAllocation>(dst.allocation), name.c_str());
 	}
 
 	Result<void, AllocateException>
@@ -1102,6 +1110,10 @@ namespace vuk {
 		upstream->deallocate_buffers(src);
 	}
 
+	void DeviceNestedResource::set_buffer_allocation_name(Buffer& dst, Name name) {
+		upstream->set_buffer_allocation_name(dst, name);
+	}
+
 	Result<void, AllocateException>
 	DeviceNestedResource::allocate_framebuffers(std::span<VkFramebuffer> dst, std::span<const FramebufferCreateInfo> cis, SourceLocationAtFrame loc) {
 		return upstream->allocate_framebuffers(dst, cis, loc);
@@ -1117,6 +1129,10 @@ namespace vuk {
 
 	void DeviceNestedResource::deallocate_images(std::span<const Image> src) {
 		upstream->deallocate_images(src);
+	}
+
+	void DeviceNestedResource::set_image_allocation_name(Image& dst, Name name) {
+		upstream->set_image_allocation_name(dst, name);
 	}
 
 	Result<void, AllocateException>


### PR DESCRIPTION
Adds an optional control over VMA allocation naming, for situations where source location sometimes does not provide enough information through `VUK_DEBUG_ALLOCATIONS`.